### PR TITLE
Pluralize listKey in find queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@keystonejs/fields": "^17.1.2",
-    "@keystonejs/list-plugins": "^7.1.1"
+    "@keystonejs/list-plugins": "^7.1.1",
+    "pluralize": "^8.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
 import { Integer } from '@keystonejs/fields';
 import { composeHook } from '@keystonejs/list-plugins/lib/utils';
+import { plural } from 'pluralize';
 
 export default ({ fieldName = 'sortOrder', ...fieldOptions } = {}) => ({
   fields = {},
@@ -30,7 +31,7 @@ export default ({ fieldName = 'sortOrder', ...fieldOptions } = {}) => ({
       const { data } = await context.executeGraphQL({
         query: `
           query {
-            items: all${listKey}s(
+            items: all${plural(listKey)}(
               ${where}
               sortBy: ${fieldName}_DESC
               first: 1
@@ -56,7 +57,7 @@ export default ({ fieldName = 'sortOrder', ...fieldOptions } = {}) => ({
     const { data } = await context.executeGraphQL({
       query: `
         query {
-          items: all${listKey}s(
+          items: all${plural(listKey)}(
             where: {
               ${fieldName}: ${resolvedData[fieldName]}
               ${existingWhere}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6303,6 +6303,11 @@ pluralize@^7.0.0:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"


### PR DESCRIPTION
Use `pluralize` when querying lists to cover more list names, ie "story" -> "stories"

Fixes #1 